### PR TITLE
fix: replace deprecated archives.builds with ids

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -68,7 +68,7 @@ builds:
 archives:
   - &archive-default
     id: default
-    builds:
+    ids:
       - default
       - windows
     name_template: '{{ .ProjectName }}-{{ .Version }}.{{ .Os }}-{{ .Arch }}{{
@@ -81,7 +81,7 @@ archives:
       - NOTICE
   - <<: *archive-default
     id: zip
-    builds:
+    ids:
       - windows
     formats:
       - zip


### PR DESCRIPTION
Summary
---

- `archives.builds` was deprecated in GoReleaser v2.8 in favour of `ids`
- Renamed both archive entries in `.goreleaser.yml`

Test plan
---

- Verify goreleaser check reports no deprecation warnings

🤖 Generated with https://claude.com/claude-code
